### PR TITLE
Brick-Break-Fetch-Canvas-For-Ball-Class

### DIFF
--- a/brickbreak/brickbreakclasses.js
+++ b/brickbreak/brickbreakclasses.js
@@ -22,6 +22,7 @@ export class Hud {
 export class Ball {
     constructor(world) {
         this.canvas = world.canvas;
+        this.ctx = world.ctx
         this.x = this.canvas.width / 2;
         this.y = this.canvas.height - 30;
         this.ballRadius = 10;


### PR DESCRIPTION
While running this code in a project I received a "this.ctx is undefined" error. Adding this.ctx to the Ball class fixes this bug.